### PR TITLE
fix: pad adjusted hex colors

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -111,7 +111,8 @@ class Game {
         let g = (num & 0x0000FF) + amount;
         if (g > 255) g = 255;
         else if (g < 0) g = 0;
-        return (usePound ? "#" : "") + (g | (b << 8) | (r << 16)).toString(16);
+        const combined = g | (b << 8) | (r << 16);
+        return (usePound ? "#" : "") + combined.toString(16).padStart(6, '0');
     }
     selectTeam(team, element) {
         const allCards = document.querySelectorAll('.team-card');


### PR DESCRIPTION
## Summary
- fix adjustColor to return valid 6-digit hex strings by padding with zeros

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ae95c2a483338f558c3896b9d2a1