### PR TITLE
Add fielder catch handling

### DIFF
--- a/js/components/fielder.js
+++ b/js/components/fielder.js
@@ -14,6 +14,18 @@ class Fielder extends Character {
                 this.x += (ball.pos.x - this.x) * 0.05;
                 this.y += (ball.pos.y - this.y) * 0.05;
                 if (dist < 15 && ball.pos.z < 20 && ball.vel.z < 0) {
+                    this.isCatching = true;
+                    ball.vel.x *= 0.2;
+                    ball.vel.y *= 0.2;
+                    ball.vel.z = 0;
+                    ball.isActive = false;
+                    if (typeof game !== 'undefined') {
+                        if (typeof game.handleWicket === 'function' && game.gameState === 'playing') {
+                            game.handleWicket('Caught!', 0);
+                        } else if (typeof game.showFeedback === 'function') {
+                            game.showFeedback('Catch!', '#FF4136');
+                        }
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- Mark fielders as catching when they reach a descending ball
- Stop the ball and flag it inactive on a catch
- Invoke wicket or feedback routines when a catch occurs

## Testing
- `node -c js/components/fielder.js`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c203836c8333a0753c6c5e54f78e