### PR TITLE
Document game initialization and pause behavior

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,13 +1,21 @@
+/**
+ * Initializes the game once the DOM content is loaded. Creates the game
+ * instance, renders the team selection screen, applies menu animations,
+ * and registers global handlers such as pausing when the page becomes
+ * hidden.
+ */
 document.addEventListener('DOMContentLoaded', () => {
     const game = new Game('gameCanvas');
     game.renderTeamSelection();
     document.querySelector('.game-title h1').classList.add('float');
     document.querySelectorAll('.menu-btn').forEach(btn => btn.classList.add('pulse'));
-    
-    // Add global pause handler
+
+    // Use visibilitychange to pause gameplay when the page is hidden
     document.addEventListener('visibilitychange', () => {
         if (document.hidden && game.gameState === 'playing') {
+            // Stop the game loop to freeze play until the tab is visible again
             game.gameLoopPaused = true;
         }
     });
 });
+


### PR DESCRIPTION
## Summary
- summarize DOMContentLoaded startup flow in main script
- explain visibility change listener and how it pauses the game

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Stick-Cricket_New/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689b148ef13c8333a14a285559c4e03c